### PR TITLE
added version support with tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,12 @@
 project( 'lumberjack' 
   , 'cpp'
-  , version : '0.0.1.-1'
+  , version : '"0.0.1.-1"'
   , license : 'Apache 2.0'
   , default_options : ['c_std=c11', 'cpp_std=c++11']
   )
+
+r = run_command('git', 'rev-parse', 'HEAD', check: true )
+git_hash = r.stdout().strip()
 
 # Make the Hourglass project
 hrgls_cmake = import('cmake')
@@ -28,6 +31,10 @@ lumberjack_lib = static_library( 'lumberjack'
   , 'src/lumberjack_basic.cpp'
   , include_directories : ['src', hrgls_includes]
   , dependencies: [hrgls_lib, thread_dep]
+  , cpp_args : [
+      '-DLJ_VERSION=@0@'.format(meson.project_version())
+      , '-DLJ_HASH="@0@"'.format(git_hash)
+    ]
   )
 
 # Build executable
@@ -41,13 +48,18 @@ executable( 'simple'
   )
 
 # Build gtest
-gtest_dep = dependency( 'gtest', fallback : ['gtest', 'gtest_dep'])
+gtest_proj = subproject('gtest')
+gtest_dep = gtest_proj.get_variable('gtest_dep')
+gmock_dep = gtest_proj.get_variable('gmock_dep')
+#gtest_dep = dependency( 'gtest', fallback : ['gtest', 'gtest_main_dep'])
+#gmock_dep = dependency( 'gmock')
+
 
 tests_src = ['tests/LumberjackUnitTests.cpp']
 tests = executable('LumberjackUnitTests'
    , sources : tests_src
    , include_directories : ['src', hrgls_includes]
-   , dependencies : [gtest_dep]
+   , dependencies : [gtest_dep, gmock_dep]
    , link_with : [lumberjack_lib]
    )
 

--- a/src/lumberjack_basic.cpp
+++ b/src/lumberjack_basic.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <filesystem>
 #include <memory>
+#include <stdlib.h>
 
 #include <chrono>
 #include <ctime>
@@ -55,6 +56,7 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
+
 /**
  * \brief make_unique replacement
  */
@@ -72,7 +74,10 @@ namespace lumberjack {
 
   class Lumberjack::impl {
     public:
-
+      impl() {
+        version_ = LJ_VERSION;
+        hash_ = LJ_HASH;
+      }
 
       /**
        * \brief connects the application to the hourglass API backend
@@ -125,12 +130,17 @@ namespace lumberjack {
 
       std::string getVersion( void )
       {
-        return version_;
+        std::stringstream ss;
+        ss << "version: "<<version_<<", hash: "<<hash_;;;
+
+        //return std::string(LJVERSION);
+        return ss.str();
       };
 
 
     private:  
-      std::string version_ = "0.0.1";
+      std::string version_;
+      std::string hash_;
       hrgls::API api_;
       Status status_ = NO_INIT;
       Severity printLevel_ = WARNING;

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,10 +1,15 @@
 [wrap-file]
-directory = googletest-release-1.10.0
+directory = googletest-release-1.11.0
+source_url = https://github.com/google/googletest/archive/release-1.11.0.tar.gz
+source_filename = gtest-1.11.0.tar.gz
+source_hash = b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
+patch_filename = gtest_1.11.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.11.0-2/get_patch
+patch_hash = 764530d812ac161c9eab02a8cfaec67c871fcfc5548e29fd3d488070913d4e94
 
-source_url = https://github.com/google/googletest/archive/release-1.10.0.zip
-source_filename = gtest-1.10.0.zip
-source_hash = 94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91
-
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.10.0/1/get_zip
-patch_filename = gtest-1.10.0-1-wrap.zip
-patch_hash = 04ff14e8880e4e465f6260221e9dfd56fea6bc7cce4c4aff0dc528e4a2c8f514
+[provide]
+dependency_names = ['gtest', 'gmock']
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep

--- a/tests/LumberjackUnitTests.cpp
+++ b/tests/LumberjackUnitTests.cpp
@@ -2,15 +2,20 @@
  * \brief Unit tests functions for Lumberjack
  */
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <lumberjack.hpp>
+
+using ::testing::HasSubstr;
 
 //Test timer accuracy
 TEST( VersionTest, delay) {
+  std::string targetVersion = "0.0.1.-1";
   lumberjack::Lumberjack lj;
   std::string version = lj.getVersion();
 
-  EXPECT_EQ( version, "0.0.1");
-  //EXPECT_TRUE( IsBetweenInclusive( result, delay - range, delay + range ));
+  EXPECT_THAT( version, HasSubstr(targetVersion));
+  EXPECT_NE( version, targetVersion );
+
 }
 
 


### PR DESCRIPTION
This merge will allow Lumberjack to pull the version as specified in the meson file and the git hash for the commit of the branch that is built.